### PR TITLE
Fix TP superswimming video

### DIFF
--- a/autowiggler/superswimming/index.html
+++ b/autowiggler/superswimming/index.html
@@ -15,5 +15,5 @@
 </head>
 <body>
     <video controls width="800px" src="wwhd.mp4"></video><br>
-    <video controls width="800px" src="tphd.mp4"></video>
+    <video controls width="800px" src="tp.mp4"></video>
 </body>


### PR DESCRIPTION
The Twilight Princess HD superswimming video currently doesn't show as the name in the HTML differed from the file name. I would have renamed the MP4 but I'm too lazy to clone the repository to my PC to rename it (you can't rename binary files on GitHub) so I changed the source file name in the HTML.